### PR TITLE
Custom gifs

### DIFF
--- a/bot/cogs/questions.txt
+++ b/bot/cogs/questions.txt
@@ -1,6 +1,6 @@
-Would you rather have dinner with Jay-Z or 500 thousand dollars?
-If you could only eat one meal for the rest of your life, what would it be?
-What did you want to be when you grew up when you were younger?
-Would you rather eat a really good mango or a really good watermelon?
-What is the longest you have gone without sleep? (WOOO ENGINEERING!)
-Are ghosts real?
+Would you rather have dinner with Jay-Z or 500 thousand dollars? | Jay-z
+If you could only eat one meal for the rest of your life, what would it be? | Food
+What did you want to be when you grew up when you were younger? | dreams
+Would you rather eat a really good mango or a really good watermelon? | fruit
+What is the longest you have gone without sleep? (WOOO ENGINEERING!) | tired
+Are ghosts real? | ghosts

--- a/bot/cogs/watercooler.py
+++ b/bot/cogs/watercooler.py
@@ -2,17 +2,20 @@ import os
 import random
 import discord
 from discord.ext import commands
-
+from giphy_client.rest import ApiException
+import giphy_client
 
 class Watercooler(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
+        self.giphy_api_key = os.getenv('GIPHY_API_KEY')
+        if not self.giphy_api_key:
+            raise ValueError("No GIPHY_API_KEY found in environment variables")
+        self.giphy_instance = giphy_client.DefaultApi()
         self.topics = self.load_topics_from_file("questions.txt")
 
     def load_topics_from_file(self, file_name):
-
         script_dir = os.path.dirname(__file__)
-
         file_path = os.path.join(script_dir, file_name)
         with open(file_path, "r") as file:
             topics = [line.strip() for line in file if line.strip()]
@@ -26,14 +29,23 @@ class Watercooler(commands.Cog):
             description=topic,
             color=discord.Color.blue()
         )
-        embed.set_image(
-            url=(
-                "https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGV0c"
-                "2pqb3N5aGpuc3U1NHRsNmRkcXJoamxrMThidHRuNjZvODZ3ciZlcD12MV9p"
-                "bnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/SeysxkSfenHY4/giphy.gif"
-            )
-        )
+
+        gif_url = self.get_gif_url(topic)
+        if gif_url:
+            embed.set_image(url=gif_url)
+        else:
+            embed.set_footer(text="No GIF found for this topic.")
+
         await ctx.send(embed=embed)
+
+    def get_gif_url(self, query):
+        try:
+            response = self.giphy_instance.gifs_search_get(self.giphy_api_key, query, limit=1)
+            if response.data:
+                return response.data[0].images.fixed_height.url
+        except ApiException as e:
+            print(f"Exception when calling Giphy API: {e}")
+        return None
 
 
 async def setup(bot):

--- a/bot/cogs/watercooler.py
+++ b/bot/cogs/watercooler.py
@@ -18,19 +18,20 @@ class Watercooler(commands.Cog):
         script_dir = os.path.dirname(__file__)
         file_path = os.path.join(script_dir, file_name)
         with open(file_path, "r") as file:
-            topics = [line.strip() for line in file if line.strip()]
+            topics = [line.strip().split('|') for line in file if line.strip()]
         return topics
 
     @commands.command(name='watercooler')
     async def watercooler(self, ctx):
-        topic = random.choice(self.topics)
+        topic_pair = random.choice(self.topics)
+        question, short_topic = topic_pair[0], topic_pair[1]
         embed = discord.Embed(
             title="Question of the Week",
-            description=topic,
+            description=question.strip(),
             color=discord.Color.blue()
         )
 
-        gif_url = self.get_gif_url(topic)
+        gif_url = self.get_gif_url(short_topic.strip())
         if gif_url:
             embed.set_image(url=gif_url)
         else:
@@ -46,7 +47,6 @@ class Watercooler(commands.Cog):
         except ApiException as e:
             print(f"Exception when calling Giphy API: {e}")
         return None
-
 
 async def setup(bot):
     await bot.add_cog(Watercooler(bot))

--- a/bot/cogs/watercooler.py
+++ b/bot/cogs/watercooler.py
@@ -5,6 +5,7 @@ from discord.ext import commands
 from giphy_client.rest import ApiException
 import giphy_client
 
+
 class Watercooler(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -41,12 +42,15 @@ class Watercooler(commands.Cog):
 
     def get_gif_url(self, query):
         try:
-            response = self.giphy_instance.gifs_search_get(self.giphy_api_key, query, limit=1)
+            response = self.giphy_instance.gifs_search_get(
+                self.giphy_api_key, query, limit=1
+            )
             if response.data:
                 return response.data[0].images.fixed_height.url
         except ApiException as e:
             print(f"Exception when calling Giphy API: {e}")
         return None
+
 
 async def setup(bot):
     await bot.add_cog(Watercooler(bot))


### PR DESCRIPTION
Now instead of using the standard Pikachu picture, we use the Giphy API to get giphs related to the question. To do this we've modified the questions.txt to include topics because querying the whole question returns no gifs.